### PR TITLE
match topics and namespaces on the can-bus while logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 type_lookup.txt
+filter_select.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/can-logger.sh
+++ b/can-logger.sh
@@ -1,9 +1,8 @@
 # Get arguments for CAN bus channel and log file size in Mb
-while getopts c:b: flag
+while getopts c: flag
 do
     case "${flag}" in
         c) channel=${OPTARG};;
-        b) baudrate=${OPTARG};;
     esac
 done
 
@@ -13,5 +12,7 @@ if [ -z "$channel" ]
 then
     echo "Please supply the a channel i.e. /dev/ttyUSBO or /COM.."
 else
-    python -m can.logger -i seeedstudio -b $baudrate -s 52428800 -c $channel -f logs/$datetime.log
+    echo "Generating filter selection file";
+    python3 source_tree.py; # regenerate filter_select.txt
+    python3 -m can.logger -i seeedstudio -b 500000 -s 52428800 -c $channel -f logs/$datetime.log --filter $(cat filter_select.txt);
 fi

--- a/filter_select.cfg
+++ b/filter_select.cfg
@@ -1,0 +1,4 @@
+/*/*_heartbeat
+/bms/bms_pack_soc
+/bms/bms_pack_voltage_current
+/mppt/mppt_power_meas_*


### PR DESCRIPTION
Small, cute little PR: the idea is that you can set filters on which messages to be logged. The filter strings match patterns using the wildcard symbol *, for example
```
/*/*_heartbeat -> matches all heartbeats
/bms/bms_pack_soc  -> matches single topic explicitly
/mppt/mppt_power_meas_* -> matches all 3 mppt power measurements
```